### PR TITLE
Alternate Kaczmarz-scheme and python2-compatibility

### DIFF
--- a/odl/contrib/electron_tomo/cast_operator.py
+++ b/odl/contrib/electron_tomo/cast_operator.py
@@ -26,14 +26,14 @@ class CastOperator(Operator):
                                 'instance.'.format(domain))
             range = domain
 
-        super().__init__(domain, range, linear=True)
+        super(CastOperator, self).__init__(domain, range, linear=True)
 
     def _call(self, x):
         return self.range.element(x.asarray())
 
     @property
     def adjoint(self):
-         return CastOperator(domain = self.range, range = self.domain)
+        return CastOperator(domain = self.range, range = self.domain)
      
         
 if __name__ == '__main__':

--- a/odl/contrib/electron_tomo/constant_phase_abs_ratio.py
+++ b/odl/contrib/electron_tomo/constant_phase_abs_ratio.py
@@ -32,7 +32,7 @@ class ConstantPhaseAbsRatio(Operator):
                                 'instance.'.format(domain))
             range = domain.complex_space
 
-        super().__init__(domain, range, linear=True)
+        super(ConstantPhaseAbsRatio, self).__init__(domain, range, linear=True)
 
         self.abs_phase_ratio = abs_phase_ratio
         self.magnitude_factor = magnitude_factor
@@ -47,7 +47,7 @@ class ConstantPhaseAbsRatio(Operator):
 
         class AbsPhaseAdj(Operator):
             def __init__(self, op):
-                super().__init__(op.range, op.domain, linear=True)
+                super(AbsPhaseAdj, self).__init__(op.range, op.domain, linear=True)
                 self.embedding_factor_c = np.conj(op.embedding_factor)
 
             def _call(self, g):

--- a/odl/contrib/electron_tomo/examples/electron_tomo_2d.py
+++ b/odl/contrib/electron_tomo/examples/electron_tomo_2d.py
@@ -71,7 +71,7 @@ callback = (odl.solvers.CallbackPrintIteration() &
             odl.solvers.CallbackShow())
 
 
-kaczmarz_plan = make_kaczmarz_plan(360, num_blocks_per_superblock = 6, method = 'random')
+kaczmarz_plan = make_kaczmarz_plan(360, num_blocks_per_superblock = 6, method = 'mls')
 
 ray_trafo_block = ray_trafo.get_sub_operator(kaczmarz_plan[0])
 

--- a/odl/contrib/electron_tomo/exp_operator.py
+++ b/odl/contrib/electron_tomo/exp_operator.py
@@ -25,7 +25,7 @@ class ExpOperator(Operator):
                                 'instance.'.format(domain))
             range = domain
 
-        super().__init__(domain, range, linear=False)
+        super(ExpOperator, self).__init__(domain, range, linear=False)
 
     def _call(self, x):
         """Implement ``self(x, out)``."""
@@ -38,7 +38,7 @@ class ExpOperator(Operator):
 
         class ExpOpDeriv(Operator):
             def __init__(self):
-                super().__init__(op.domain, op.range, linear=True)
+                super(ExpOpDeriv, self).__init__(op.domain, op.range, linear=True)
 
             def _call(self, h):
                 return exp_f * h
@@ -47,7 +47,7 @@ class ExpOperator(Operator):
             def adjoint(self):
                 class ExpOpDerivAdj(Operator):
                     def __init__(self):
-                        super().__init__(op.range, op.domain, linear=True)
+                        super(ExpOpDerivAdj, self).__init__(op.range, op.domain, linear=True)
 
                     def _call(self, g):
                         return exp_f.conj() * g

--- a/odl/contrib/electron_tomo/image_formation_etomo.py
+++ b/odl/contrib/electron_tomo/image_formation_etomo.py
@@ -65,6 +65,7 @@ def modulation_transfer_function(x, **kwargs):
 
     return result
 
+
 def optics_imperfections(x, **kwargs):
     """Function encoding the phase shifts due to optics imperfections.
 
@@ -102,6 +103,7 @@ def optics_imperfections(x, **kwargs):
     result = np.exp(1j * result)
 
     return result
+
 
 def make_imageFormationOp(domain, wave_number, spherical_abe, defocus, det_size,
                           magnification, abs_phase_ratio = 1.0, obj_magnitude=1.0, **kwargs):

--- a/odl/contrib/electron_tomo/intensity_op.py
+++ b/odl/contrib/electron_tomo/intensity_op.py
@@ -45,7 +45,7 @@ class IntensityOperator(Operator):
                                 'instance.'.format(domain))
             range = domain.real_space
 
-        super().__init__(domain, range, linear=False)
+        super(IntensityOperator, self).__init__(domain, range, linear=False)
 
     def _call(self, x, out):
         """Implement ``self(x, out)``."""
@@ -83,7 +83,7 @@ class IntensityOperator(Operator):
 
         class IntensOpDeriv(Operator):
             def __init__(self):
-                super().__init__(op.domain, op.range, linear=True)
+                super(IntensOpDeriv, self).__init__(op.domain, op.range, linear=True)
 
             def _call(self, h):
                 return 2 * (f.real * h.real + f.imag * h.imag)
@@ -92,7 +92,7 @@ class IntensityOperator(Operator):
             def adjoint(self):
                 class IntensOpDerivAdj(Operator):
                     def __init__(self):
-                        super().__init__(op.range, op.domain, linear=True)
+                        super(IntensOpDerivAdj, self).__init__(op.range, op.domain, linear=True)
 
                     def _call(self, g, out):
                         out.real[:] = 2 * g * f.real

--- a/odl/contrib/electron_tomo/kaczmarz_util.py
+++ b/odl/contrib/electron_tomo/kaczmarz_util.py
@@ -11,7 +11,7 @@ from odl.contrib.electron_tomo.cast_operator import CastOperator
 from random import shuffle
 
 
-def make_kaczmarz_plan(num_blocks, method='sequential',
+def make_kaczmarz_plan(num_blocks, method='random',
                        num_blocks_per_superblock=1):
 
     indices = list(range(num_blocks))
@@ -23,8 +23,9 @@ def make_kaczmarz_plan(num_blocks, method='sequential',
                      for j in range(num_super_blocks)]
 
     if method == 'random':
-        # TODO: shuffle indices
         shuffle(block_indices)
+    elif method == 'mls
+        makeMLSOrder(block_indices)
     elif method == 'sequential':
         pass
 

--- a/odl/contrib/electron_tomo/kaczmarz_util.py
+++ b/odl/contrib/electron_tomo/kaczmarz_util.py
@@ -6,9 +6,10 @@ Created on Tue Oct 17 10:23:11 2017
 @author: zickert
 """
 
+import numpy as np
 import odl
 from odl.contrib.electron_tomo.cast_operator import CastOperator
-from random import shuffle
+from random import shuffle, randint
 
 
 def make_kaczmarz_plan(num_blocks, method='random',
@@ -22,14 +23,54 @@ def make_kaczmarz_plan(num_blocks, method='random',
     block_indices = [indices[j*num_blocks_per_superblock: (j+1)*num_blocks_per_superblock]
                      for j in range(num_super_blocks)]
 
-    if method == 'random':
+    if method == 'random':          # Randomized ordering
         shuffle(block_indices)
-    elif method == 'mls
-        makeMLSOrder(block_indices)
-    elif method == 'sequential':
+    elif method == 'mls':           # (M)ulti-(L)evel (S)cheme by Guan and Gordon (2005)
+        block_indices = get_mls_order(block_indices)
+    elif method == 'sequential':    # Retain sequential ordering
         pass
 
     return block_indices
+
+
+# Sorts a list of tomographic angles (ideally between 0 and 180 degrees)
+# such that the order represents the (M)ulti-(L)evel (S)cheme proposed by
+#
+# Guan and Gordon. Physics in medicine and biology 39.11 (1994): 2005.
+#
+# as a processing order for tomographic projections in Kaczmarz/ART-
+# iterations.
+def get_mls_order(tomo_angle_list, start_idx = None):
+
+    length = len(tomo_angle_list)
+
+    # Assign random start-index if not given
+    if start_idx is None:
+        start_idx = randint(0, length-1)
+
+    # Extend list to have a length of 2^p for some integer p
+    pow2_length = next_greater_power_of_2(length)
+    pow2 = pow2_length.bit_length()-1
+    #tomo_angle_list.extend(tomo_angle_list[:pow2_length-length])
+
+    # Compute MLS-order for list of size 2^p
+    order = np.arange(pow2_length)
+    for jj in range(pow2):
+        # divide-and-conquer-shuffling 
+        order = np.reshape(order, (2**jj, pow2_length/2**(jj+1), 2))
+        order = np.transpose(order, (0,2,1))
+        order = np.reshape(order, (pow2_length,) )
+    
+    # Smartly truncate to get quasi MLS-order for length != 2^p
+    order = np.round((length/(1.*pow2_length)) * order).astype(np.int32)    # Map indices to given length
+    order = (order + start_idx) % length                                    # Set start index
+
+    # Ensure that every index occurs exactly once (annoying two-liner
+    # since numpy.unique likes to sort the array, which is not desired here)
+    _, unique_idx = np.unique(order, return_index=True) 
+    order = np.delete(order, np.setdiff1d(np.arange(pow2_length), unique_idx))
+    
+    return np.array(tomo_angle_list)[order].tolist()
 
 
 def make_Op_blocks(block_indices, Block_Op, Op_pre = None, Op_post = None):
@@ -62,6 +103,18 @@ def make_data_blocks(data, block_indices, block_axis = 0):
         return data.asarray()[block_indices[idx]]
     
     return get_data_block
+
+
+# For a given integer n, computes the smallest m such that m>=n
+# m = 2^p for some integer p
+def next_greater_power_of_2(x):  
+        return 2**(x-1).bit_length()
+
+
+
+if __name__ == '__main__':
+    print(get_mls_order(list(range(180))))
+    print(get_mls_order([[2*jj, 2*jj+1] for jj in range(27)]))
     
 
 


### PR DESCRIPTION
Hey,

I implemented the Kaczmarz-sampling scheme that I spoke about. Moreover, I realised that our use of "super()" (without arguments) is not supported by python2. So I changed that, as well.

(Sorry for the mess in some of the commits - essentially, I really just changed the above)

Next, I want to try eliminating the boundary-artifacts in the Kaczmarz-iterations with gradient penalty.