### PR TITLE
Fixed boundary artifacts for kaczmarz-SART

### DIFF
--- a/odl/contrib/etomo/kaczmarz_alg.py
+++ b/odl/contrib/etomo/kaczmarz_alg.py
@@ -1,10 +1,5 @@
 import odl
 import numpy as np
-<<<<<<< HEAD
-=======
-import pylab as pl
-from time import sleep
->>>>>>> 2dfb848... Fixed boundary artifacts in kaczmarz_SART_method
 from odl.contrib.etomo.cast_operator import CastOperator
 from odl.contrib.etomo.block_ray_trafo import BlockRayTransform
 from odl.contrib.etomo.kaczmarz_util import make_kaczmarz_plan

--- a/odl/contrib/etomo/kaczmarz_alg.py
+++ b/odl/contrib/etomo/kaczmarz_alg.py
@@ -1,5 +1,10 @@
 import odl
 import numpy as np
+<<<<<<< HEAD
+=======
+import pylab as pl
+from time import sleep
+>>>>>>> 2dfb848... Fixed boundary artifacts in kaczmarz_SART_method
 from odl.contrib.etomo.cast_operator import CastOperator
 from odl.contrib.etomo.block_ray_trafo import BlockRayTransform
 from odl.contrib.etomo.kaczmarz_util import make_kaczmarz_plan
@@ -7,7 +12,7 @@ from odl.contrib.etomo.kaczmarz_util import make_data_blocks
 from odl.contrib.etomo.kaczmarz_util import make_Op_blocks
 
 
-__all__ = ('kaczmarz_reco_method', 'kaczmarz_SART_method')
+__all__ = ('kaczmarz_reco_method', 'kaczmarz_SART_method', 'get_nonnegativity_projection')
 
 
 def kaczmarz_reco_method(get_Op, reco, get_data, num_iterates_per_cycle,
@@ -22,17 +27,6 @@ def kaczmarz_reco_method(get_Op, reco, get_data, num_iterates_per_cycle,
             data = op.range.element(get_data(it))
 
             residual = data - op(reco)
-
-#            if do_CG_on_data_space:
-#
-#                A = op.derivative(reco)
-#                B = odl.IdentityOperator(A.range)
-#                T = A * A.adjoint + regpar * B.adjoint * B
-#
-#                d_reco_T = residual.space.zero()
-#                odl.solvers.conjugate_gradient(T, d_reco_T, residual,
-#                                               niter=niter_CG)
-#                d_reco = A.adjoint(d_reco_T)
 
             A = op.derivative(reco)
             B = odl.IdentityOperator(reco.space)
@@ -80,21 +74,38 @@ def kaczmarz_SART_method(get_ProjOp, reco, get_data, num_iterates_per_cycle,
 
             if imageFormationOp is not None or gamma_H1 > 0:
 
+                # Support of the unit-projection
+                unit_proj_np = unit_proj.asarray()
+                unit_proj_max = np.max(unit_proj_np)
+                unit_proj_supp = (unit_proj_np >= 1e-4*unit_proj_max)
+                #
+                # Version without boundary points for improved numerical stability
+                unit_proj_supp_noBoundary = unit_proj_supp * np.roll(unit_proj_supp, -1, axis=1) * np.roll(unit_proj_supp, 1, axis=1)
+                if p_reco.space.ndim > 2:
+                    unit_proj_supp_noBoundary *= np.roll(unit_proj_supp, -1, axis=2) * np.roll(unit_proj_supp, 1, axis=2)
+
+                # Regularize the unit-projection for numerical stability
+                unit_proj_np[np.logical_not(unit_proj_supp)] = 1e-4*unit_proj_max
+
                 # Assemble operators for optimization in projection-space
                 A = imageFormOp.derivative(p_reco)
+                A_tilde_factor = p_reco.space.element(unit_proj_sqrt * unit_proj_supp_noBoundary)
+                A_tilde = A * A_tilde_factor
+
+                # Assemble right hand side for CG-iterations
+                b = A_tilde.adjoint(residual)
+
+                # Assemble forward operator for CG-iterations
                 if gamma_H1 > 0:
-                    # Regularize the unit-projection for numerical stability
-                    unit_proj_np = unit_proj.asarray()
-                    unit_proj_max = np.max(unit_proj_np)
-                    unit_proj_supp = (unit_proj_np >= 1e-2*unit_proj_max)
-                    unit_proj_np[unit_proj_np < 1e-6*unit_proj_max] = 1e-6*unit_proj_max
                     
-                    # Define derivative such that it only acts within the support
+                    # Define derivative such that it only acts within the unit-projection support
                     unit_proj_supp_dd1 = p_reco.space.element(unit_proj_supp * np.roll(unit_proj_supp, -1, axis=1))
                     dd1 = unit_proj_supp_dd1 * odl.PartialDerivative(p_reco.space, 1)
                     
                     dd1_log_unit_proj = dd1(0.5 * np.log(unit_proj))
                     dd1_proj = dd1 - odl.MultiplyOperator(dd1_log_unit_proj, domain=dd1.domain, range=dd1.range)
+
+                    # Additional derivative along the tomographic axis in the 3D case 
                     if p_reco.space.ndim > 2:
                         unit_proj_supp_dd2 = p_reco.space.element(unit_proj_supp * np.roll(unit_proj_supp, -1, axis=2))
                         dd2 = unit_proj_supp_dd2 * odl.PartialDerivative(p_reco.space, 2)
@@ -102,41 +113,48 @@ def kaczmarz_SART_method(get_ProjOp, reco, get_data, num_iterates_per_cycle,
                         dd2_proj = dd2 - odl.MultiplyOperator(dd2_log_unit_proj, domain=dd2.domain, range=dd2.range)
                         grad_proj = odl.BroadcastOperator(dd1_proj, dd2_proj)
                     else:
-                        grad_proj = dd1_proj 
-                    T = (unit_proj_sqrt * (A.adjoint * (A * unit_proj_sqrt))) + (regpar*(1.0-gamma_H1)) * odl.IdentityOperator(p_reco.space) + (regpar*gamma_H1) * (grad_proj.adjoint * grad_proj)
-                else:
-                    T = (unit_proj_sqrt * (A.adjoint * (A * unit_proj_sqrt))) + regpar * odl.IdentityOperator(p_reco.space)
+                        grad_proj = dd1_proj
 
-                b = unit_proj_sqrt * A.adjoint(residual)
+                    T = (A_tilde.adjoint * A_tilde) + (regpar*(1.0-gamma_H1)) * odl.IdentityOperator(p_reco.space) + (regpar*gamma_H1) * (grad_proj.adjoint * grad_proj)
+
+                else:
+
+                    T = (A_tilde.adjoint * A_tilde) + regpar * odl.IdentityOperator(p_reco.space)
 
                 # Solve for increment in projection
                 d_p_tilde = T.domain.zero()
                 odl.solvers.conjugate_gradient(T, d_p_tilde, b, niter=niter_CG)
 
-                # Apply inverse preconditioner (regularized for numerical stability)
-                unit_proj_sqrt_np = unit_proj_sqrt.asarray()
-                unit_proj_sqrt_max = np.max(unit_proj_sqrt_np)
-                unit_proj_sqrt_np[unit_proj_sqrt_np < 1e-2*unit_proj_sqrt_max] = 1e-2*unit_proj_sqrt_max
-                d_p_tilde /= unit_proj_sqrt
+                # Apply inverse preconditioner within the unit-projection support
+                # (outside, d_p_tilde vanishes anyway) 
+                d_p_tilde.asarray()[unit_proj_supp_noBoundary] /= unit_proj_sqrt.asarray()[unit_proj_supp_noBoundary]
 
             else:
 
                 d_p_tilde = residual / (unit_proj + regpar)
 
             # Back-project and increment
-            #backproj_correction_factor = ray_trafo.range.cell_volume/(ray_trafo.domain.cell_volume*ray_trafo.range.cell_sides[0])
             backproj_correction_factor = 1.0/ray_trafo.range.cell_sides[0]
-#            unit_proj_2 = backproj_correction_factor * ray_trafo(ray_trafo.adjoint(ray_trafo.range.one()))
-#            unit_proj_2.show()
-#            unit_proj.show()
-
             reco += ray_trafo.adjoint(backproj_correction_factor * d_p_tilde)
 
+            # Apply optional projection in object space, e.g. onto non-negative objects
             if projection is not None:
                 projection(reco)
 
             if callback is not None:
                 callback(reco)
+
+
+# Lp-projection onto non-negative objects
+def get_nonnegativity_projection(domain):
+
+    nonneg_constraint = odl.solvers.IndicatorNonnegativity(domain).proximal(1)
+
+    def nonnegativity_projection(x):
+        x[:] = nonneg_constraint(x)
+
+    return nonnegativity_projection
+
 
 
 if __name__ == '__main__':
@@ -168,7 +186,7 @@ if __name__ == '__main__':
 
     kaczmarz_plan = make_kaczmarz_plan(num_angles,
                                        block_length=num_angles_per_block,
-                                       method='random')
+                                       method='mls')
     get_op = make_Op_blocks(kaczmarz_plan, block_ray_trafo)
     get_data = make_data_blocks(data, kaczmarz_plan)
 
@@ -176,4 +194,5 @@ if __name__ == '__main__':
     #  kaczmarz_reco_method(get_op, reco, get_data, len(kaczmarz_plan), regpar, callback=callback, num_cycles=num_cycles)
     kaczmarz_SART_method(get_op, reco, get_data, len(kaczmarz_plan), regpar,
                          imageFormationOp=odl.IdentityOperator(get_op(0).range),
-                         callback=callback, num_cycles=num_cycles)
+                         callback=callback, num_cycles=num_cycles,
+                         projection=get_nonnegativity_projection(reco_space))


### PR DESCRIPTION
I now (hopefully and finally) fixed the boundary artifacts occuring with kaczmarz_sart_method. To this end, I essentially had to prevent that anything is reconstructed on the boundary points of the unit-projection support, see code.

Moreover, I introduced a function that assembles the projection of objects onto non-negative values, which we use as a constraint. Thereby, the example code in electron_tomo_2d.py and electron_tomo_3d.py can be shortened a bit and everything seems slightly more tidied up.

Cheers,
Simon